### PR TITLE
Fill title in header/footer

### DIFF
--- a/src/core/evaluators.ts
+++ b/src/core/evaluators.ts
@@ -227,9 +227,15 @@ export async function getHeadersEvaluator(basePdfBuffer: Uint8Array) {
       }
     }
 
+    let elements;
+
     // fill total page
-    let elements = document.getElementsByClassName("totalPages");
+    elements = document.getElementsByClassName("totalPages");
     setElementsValue(elements, pagesCount.toString());
+
+    // fill title
+    elements = document.getElementsByClassName("title");
+    setElementsValue(elements, document.title);
   };
 
   return [doc, pageFunc, argument] as [


### PR DESCRIPTION
Currently, the puppeteer PDF generation allows to dynamically include the HTML title in the header/footer: https://github.com/puppeteer/puppeteer/blob/v5.3.1/docs/api.md#pagepdfoptions

This PR adds that option as well:

HTML:
```html
...
<title>My title</title>
...

<div id="footer">
  <span class="title"></span> <span class="pageNumber"></span> of <span class="totalPages"></span>
</div>
```

PDF:
![Screenshot from 2020-10-11 12-44-06](https://user-images.githubusercontent.com/3299231/95683102-88feef80-0bbf-11eb-9d98-1e4b10df89f0.png)
