### PR TITLE
feat: trigger change event after setting totalPages value

### DIFF
--- a/src/core/evaluators.ts
+++ b/src/core/evaluators.ts
@@ -233,6 +233,11 @@ export async function getHeadersEvaluator(basePdfBuffer: Uint8Array) {
     const totalPagesElements = document.getElementsByClassName("totalPages");
     setElementsValue(totalPagesElements, pagesCount.toString());
 
+    // trigger changes so JS can modify totalPages too
+    for(const element of totalPagesElements) {
+      element.dispatchEvent(new Event("change", { bubbles: true }));
+    }
+    
     // fill title
     const titleElements = document.getElementsByClassName("title");
     setElementsValue(titleElements, document.title);


### PR DESCRIPTION
Problem: I want to hide the page number indicator if there is only one page. The code to do that is:

```html
  <script>
    function onFooterChange(element) {
      if (element.textContent.trim() === '1/1') {
        element.style.display = 'none'
      }
    }
  </script>
  <div id="footer" class="absolute right-1 bottom-1" onchange="onFooterChange(this)">
    <p class="text-sm"><span class="pageNumber"></span>/<span class="totalPages"></span></p>
  </div>
```

However, the `change` event is only called when `pageNumber` is inserted and **not** at any point after `totalPages` has its value set. This PR rectifies this by dispatching the change event on each `totalPages` element after setting the values.

I may also suggest that the calling behaviour of the JS be explained better in documentation as this wasn't clear to me without reading the source - however, the source is very easy to read so it's not a big deal. Not in scope of this PR anyway. For now I am using `patch-package` to add this feature to my project. Thank you for this great library, other than this it was exactly what I was looking for.