### PR TITLE
Use the Multiply blend mode to combine layers properly

### DIFF
--- a/src/core/createReport.ts
+++ b/src/core/createReport.ts
@@ -1,4 +1,4 @@
-import { PDFDocument } from "pdf-lib";
+import { PDFDocument, BlendMode } from "pdf-lib";
 
 export async function createReport(
   baseDoc: PDFDocument,
@@ -70,6 +70,7 @@ export async function createReport(
         ...size,
         x: x - size.width,
         y: y - size.height,
+        blendMode: BlendMode.Multiply
       });
     }
 
@@ -78,6 +79,7 @@ export async function createReport(
         ...size,
         x: x - size.width,
         y: 0,
+        blendMode: BlendMode.Multiply
       });
     }
 


### PR DESCRIPTION
## Problem

Right now the header and footer are drawn on top of the main content using the `Normal` blend mode.

https://en.wikipedia.org/wiki/Blend_modes#Normal_blend_mode

Normal blend mode does not combine colors. New PDF viewers can figure out how to display such content, some older ones seem to have trouble displaying the main content.

## Solution

To fix that, we can use the `Multiply` blend mode, which combines them properly. In this case it doesn't matter which layer is above or below.

I'd be happy to add some specs, didn't want to introduce `ava` or `jest` here to avoid potential merge conflicts with the other ongoing branch. Thanks!