### PR TITLE
Fix a rounding error when scale is used

### DIFF
--- a/src/core/evaluators.ts
+++ b/src/core/evaluators.ts
@@ -33,12 +33,12 @@ export function getHeightEvaluator(
         const position = element.style.position;
         element.style.position = "absolute";
 
-        const height = Math.ceil(element.offsetHeight + margin);
+        const height = element.offsetHeight + margin;
 
         // reset element position
         element.style.position = position;
 
-        return height;
+        return Math.ceil(height * scale);
       }
       return 0;
     };
@@ -60,8 +60,8 @@ export function getHeightEvaluator(
       styleSheet.insertRule(`#footer { margin-bottom: ${marginBottom}`);
     }
 
-    const headerHeight = getHeight(header) * scale;
-    const footerHeight = getHeight(footer) * scale ;
+    const headerHeight = getHeight(header);
+    const footerHeight = getHeight(footer);
 
     return { headerHeight, footerHeight };
   };


### PR DESCRIPTION
## Problem

When scale is used, you can run into a rounding issue.

## Solution

Move `Math.ceil` and use it after `scale` is applied in calculations.

I'll add specs as soon as other branches are merged. Thanks a lot again!