### PR TITLE
Copy common meta data from page to PDF

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -67,7 +67,7 @@ async function pdfPage(page: Page, options?: PDFOptions): Promise<Uint8Array> {
   meta_item = await page.evaluate(() => { var _el = document.querySelector('head meta[name=subject]'); return _el ? _el.content : null });
   if (meta_item) doc.setSubject(meta_item);
   meta_item = await page.evaluate(() => { var _el = document.querySelector('head meta[name=keywords]'); return _el ? _el.content : null });
-  if (meta_item) doc.setKeywords(meta_item);
+  if (meta_item) doc.setKeywords(meta_item.split(","));
 
   const result = await core.createReport(
     doc,

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,12 +60,12 @@ async function pdfPage(page: Page, options?: PDFOptions): Promise<Uint8Array> {
   const headerPdfBuffer = await page.pdf(pdfOptions);
 
   const metaData = await page.evaluate(() => {
-    {
-      title:    document.querySelector('head > title')?.innerText,
-      author:   document.querySelector('head meta[name=author]')?.innerText,
-      subject:  document.querySelector('head meta[name=subject]')?.innerText,
-      keywords: document.querySelector('head meta[name=keywords]')?.innerText?.split(','),
-    }
+    return {
+      title:    (<HTMLElement>document.querySelector('head > title'))?.innerText,
+      author:   (<HTMLElement>document.querySelector('head meta[name=author]'))?.innerText,
+      subject:  (<HTMLElement>document.querySelector('head meta[name=subject]'))?.innerText,
+      keywords: (<HTMLElement>document.querySelector('head meta[name=keywords]'))?.innerText?.split(','),
+    };
   });
   if (metaData) {
     if (metaData.title)    doc.setTitle(metaData.title);

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,15 +59,20 @@ async function pdfPage(page: Page, options?: PDFOptions): Promise<Uint8Array> {
 
   const headerPdfBuffer = await page.pdf(pdfOptions);
 
-  let meta_item;
-  meta_item = await page.evaluate(() => { var _el = document.querySelector('head > title'); return _el ? _el.innerText : null });
-  if (meta_item) doc.setTitle(meta_item);
-  meta_item = await page.evaluate(() => { var _el = document.querySelector('head meta[name=author]'); return _el ? _el.content : null });
-  if (meta_item) doc.setAuthor(meta_item);
-  meta_item = await page.evaluate(() => { var _el = document.querySelector('head meta[name=subject]'); return _el ? _el.content : null });
-  if (meta_item) doc.setSubject(meta_item);
-  meta_item = await page.evaluate(() => { var _el = document.querySelector('head meta[name=keywords]'); return _el ? _el.content : null });
-  if (meta_item) doc.setKeywords(meta_item.split(","));
+  const metaData = await page.evaluate(() => {
+    {
+      title:    document.querySelector('head > title')?.innerText,
+      author:   document.querySelector('head meta[name=author]')?.innerText,
+      subject:  document.querySelector('head meta[name=subject]')?.innerText,
+      keywords: document.querySelector('head meta[name=keywords]')?.innerText?.split(','),
+    }
+  });
+  if (metaData) {
+    if (metaData.title)    doc.setTitle(metaData.title);
+    if (metaData.author)   doc.setAuthor(metaData.author);
+    if (metaData.subject)  doc.setSubject(metaData.subject);
+    if (metaData.keywords) doc.setKeywords(metaData.keywords);
+  }
 
   const result = await core.createReport(
     doc,

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,6 +59,16 @@ async function pdfPage(page: Page, options?: PDFOptions): Promise<Uint8Array> {
 
   const headerPdfBuffer = await page.pdf(pdfOptions);
 
+  let meta_item;
+  meta_item = await page.evaluate(() => { var _el = document.querySelector('head > title'); return _el ? _el.innerText : null });
+  if (meta_item) doc.setTitle(meta_item);
+  meta_item = await page.evaluate(() => { var _el = document.querySelector('head meta[name=author]'); return _el ? _el.content : null });
+  if (meta_item) doc.setAuthor(meta_item);
+  meta_item = await page.evaluate(() => { var _el = document.querySelector('head meta[name=subject]'); return _el ? _el.content : null });
+  if (meta_item) doc.setSubject(meta_item);
+  meta_item = await page.evaluate(() => { var _el = document.querySelector('head meta[name=keywords]'); return _el ? _el.content : null });
+  if (meta_item) doc.setKeywords(meta_item);
+
   const result = await core.createReport(
     doc,
     headerPdfBuffer,


### PR DESCRIPTION
# Problem

Common meta-data of the generated PDF are blank, these includes `title`, `author`, `subject`.
These meta data may be available in the original HTML page.

# Solution

Grab these meta data from the HTML page if they exists and set them in the resulting PDF.
