### PR TITLE
fix: Headers/Footers with different page sizes

### DIFF
--- a/src/core/createReport.ts
+++ b/src/core/createReport.ts
@@ -1,102 +1,77 @@
-import { PDFDocument, BlendMode } from "pdf-lib";
+import { PDFDocument, BlendMode } from 'pdf-lib';
 
 export async function createReport(
   baseDoc: PDFDocument,
   headersPdfBuffer: Uint8Array,
+  footerPdfBuffer: Uint8Array,
   headerHeight: number,
   footerHeight: number
 ) {
   const headerDoc = await PDFDocument.load(headersPdfBuffer);
+  const footerDoc = await PDFDocument.load(footerPdfBuffer);
 
   const basePages = baseDoc.getPages();
   const headerPages = headerDoc.getPages();
-
-  const hasBoth = !!headerHeight && !!footerHeight;
-
-  // get pages dimensions
-  const x = basePages[0].getWidth();
-  const y = basePages[0].getHeight();
+  const footerPages = footerDoc.getPages();
 
   // 1 inch = 96 px
   // PDF unit =  inch * 72/1
   const pdfHeaderHeight = (headerHeight / 96) * 72;
   const pdfFooterHeight = (footerHeight / 96) * 72;
 
-  // embed all headers pdf pages in the base pdf
-  const pages = [];
-  const boxes = [];
+  const headerBoxes = headerPages.map((page) => {
+    const width = page.getWidth();
+    const height = page.getHeight();
+    return {
+      bottom: height - pdfHeaderHeight,
+      left: 0,
+      right: width,
+      top: height,
+    };
+  });
+  const footerBoxes = footerPages.map((page) => {
+    const width = page.getWidth();
+    const height = page.getHeight();
+    return {
+      bottom: height - pdfFooterHeight,
+      left: 0,
+      right: width,
+      top: height,
+    };
+  });
+  const embeddedHeaderPages = await baseDoc.embedPages(
+    headerPages,
+    headerBoxes
+  );
+  const embeddedFooterPages = await baseDoc.embedPages(
+    footerPages,
+    footerBoxes
+  );
+  for (let i = 0; i < basePages.length; i++) {
+    const page = basePages[i];
+    const width = page.getWidth();
+    const height = page.getHeight();
+    const embeddedHeaderPage = embeddedHeaderPages[i];
+    if (embeddedHeaderPage) {
+      const size = embeddedHeaderPage.size();
 
-  for (let i = 1; i <= headerPages.length; i++) {
-    pages.push(headerPages[i - 1]);
-
-    const isOdd = i % 2 != 0;
-
-    // have only header or
-    // have both header and footer and we are in odd pages
-    // 1, 3, 5, etc
-    if (headerHeight && (!hasBoth || isOdd)) {
-      boxes.push({
-        bottom: y - pdfHeaderHeight,
-        left: 0,
-        right: x,
-        top: y!,
-      });
-    }
-
-    // have only footer or
-    // have both header and footer and we are in plural pages
-    // 2, 4, 6, etc
-    if (footerHeight && (!hasBoth || !isOdd)) {
-      boxes.push({
-        bottom: y - pdfFooterHeight,
-        left: 0,
-        right: x,
-        top: y!,
-      });
-    }
-  }
-
-  const embeddedPages = await baseDoc.embedPages(pages, boxes);
-
-  // draw headers and/or footers over the base pages
-  let baseIndex = 0;
-  for (let i = 1; i <= headerPages.length; i++) {
-    const embeddedPage = embeddedPages[i - 1];
-    const size = embeddedPage.size();
-    const isOdd = i % 2 != 0;
-
-    if (headerHeight && (!hasBoth || isOdd)) {
-      basePages[baseIndex].drawPage(embeddedPage, {
+      page.drawPage(embeddedHeaderPage, {
         ...size,
-        x: x - size.width,
-        y: y - size.height,
-        blendMode: BlendMode.Multiply
+        x: width - size.width,
+        y: height - size.height,
+        blendMode: BlendMode.Multiply,
       });
     }
+    const embeddedFooterPage = embeddedFooterPages[i];
+    if (embeddedFooterPage) {
+      const size = embeddedFooterPage.size();
 
-    if (footerHeight && (!hasBoth || !isOdd)) {
-      basePages[baseIndex].drawPage(embeddedPage, {
+      page.drawPage(embeddedFooterPage, {
         ...size,
-        x: x - size.width,
+        x: width - size.width,
         y: 0,
-        blendMode: BlendMode.Multiply
+        blendMode: BlendMode.Multiply,
       });
-    }
-
-    // when we have both header and footer
-    // two pages of headers pdf belong to one page of the base doc
-    //  ------------
-    // |  header 1  |
-    // |            |        ------------
-    // |            |       |  header 1  |
-    //  ------------     => | xxxxxxxxxx |
-    // |  footer 1  |       |  footer 1  |
-    // |            |        ------------
-    // |            |
-    if (hasBoth && !isOdd) {
-      baseIndex++;
-    } else if (!hasBoth) {
-      baseIndex++;
     }
   }
 

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -2,5 +2,6 @@ export { createReport } from "./createReport";
 export {
   getBaseEvaluator,
   getHeadersEvaluator,
+  getFootersEvaluator,
   getHeightEvaluator,
 } from "./evaluators";

--- a/src/types.ts
+++ b/src/types.ts
@@ -140,6 +140,8 @@ export interface PDFOptions {
 
 export interface Page {
   pdf(options?: PDFOptions): Promise<Buffer>;
+  content(): Promise<string>;
+  setContent(content: string): Promise<void>;
   goto(url: string): Promise<unknown>;
   close(): Promise<void>;
   evaluate<T extends EvaluateFn>(


### PR DESCRIPTION
Now evaluates headers separately from footers:
Renders page without headers/footers
Renders headers into PDF
Renders footers into PDF
Draws Header into main PDF
Draws Footers into main PDF

refs: https://github.com/PejmanNik/puppeteer-report/issues/40

Please, test before merging. The code can be optimized, but works for me now. 
At least - createReport now is more readable than before 
