### PR TITLE
Fix flex header/footer getting assigned display: block

### DIFF
--- a/src/core/evaluators.ts
+++ b/src/core/evaluators.ts
@@ -171,7 +171,7 @@ export async function getHeadersEvaluator(basePdfBuffer: Uint8Array) {
 
     const resetStyle = (element: HTMLElement | null) => {
       if (element) {
-        element.style.display = "block";
+        element.style.display = "";
       }
     };
 


### PR DESCRIPTION
The reset style assumed that the `display` value of the header/footer was block. The new approach unsets `display: none` which re-enables the style applied with CSS.

This will not properly reset original inline styles. This would require saving the display value and restoring it later. If this is preferred, I could make this change.

> [A style declaration is reset by setting it to null or an empty string ­–mdn](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/style#setting_styles)